### PR TITLE
Removed logo background color

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Copenhagen",
   "author": "Zendesk",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "api_version": 2,
   "default_locale": "en-us",
   "settings": [

--- a/style.css
+++ b/style.css
@@ -662,7 +662,6 @@ ul {
 }
 
 .logo .row {
-  background-color: #a31f34;
   display: flex;
 }
 

--- a/style.css
+++ b/style.css
@@ -677,7 +677,7 @@ ul {
 
 .logo .column .micromasters-logo {
   height: 20px;
-  width: 180px;
+  width: 185px;
 }
 
 .logo .divider-large {

--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -26,7 +26,7 @@ $header-height: 50px;
     }
     .micromasters-logo {
       height: 20px;
-      width: 180px;
+      width: 185px;
     }
   }
   .divider-large {

--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -14,7 +14,6 @@ $header-height: 50px;
 
 .logo {
   .row {
-    background-color: $mm-brand-bg;
     display: flex;
   }
   .column {


### PR DESCRIPTION
### Description
Removes background shade color from MIT logo.
Also fixes the logo trimming from the end in Safari.

The changes can be tested on Temporary live deployment [here](https://mmtestsupport.zendesk.com/hc/en-us)

### Related Ticket
#3 


### Screenshots
**New**
<img width="1438" alt="Screenshot 2021-02-16 at 2 14 03 PM" src="https://user-images.githubusercontent.com/34372316/108053216-f095e180-706e-11eb-82b4-59bb3dc17db7.png">

**Old**
<img width="1440" alt="Screenshot 2021-02-16 at 3 54 02 PM" src="https://user-images.githubusercontent.com/34372316/108053448-3fdc1200-706f-11eb-9a14-9c44217e7d7f.png">
