### PR TITLE
Update theme header design

### DIFF
--- a/style.css
+++ b/style.css
@@ -648,10 +648,10 @@ ul {
   position: relative;
   align-items: center;
   display: flex;
-  height: 50px;
+  height: 57px;
   justify-content: space-between;
-  background-color: #90192c;
-  padding: 5px 15% 5px 15%;
+  background-color: #a31f34;
+  padding: 5px 2% 5px 2%;
 }
 
 @media (min-width: 100%) {
@@ -671,20 +671,21 @@ ul {
 }
 
 .logo .column .mit-logo {
-  height: 20px;
-  width: 40px;
+  height: 36px;
+  width: 51px;
 }
 
 .logo .column .micromasters-logo {
-  height: 20px;
-  width: 185px;
+  height: 23px;
+  width: 263px;
+  margin-top: 8px;
 }
 
 .logo .divider-large {
   flex: 33.33%;
   width: 1px;
-  height: 20px;
-  margin: 5px 5px 0 0;
+  height: 30px;
+  margin: 8px 10px 0 10px;
   border-left: 1px solid rgba(255, 255, 255, 0.5);
 }
 
@@ -705,7 +706,7 @@ ul {
   border: solid 1px #ddd;
   right: 0;
   left: 0;
-  top: 50px;
+  top: 57px;
   z-index: 1;
 }
 

--- a/style.css
+++ b/style.css
@@ -667,7 +667,7 @@ ul {
 
 .logo .column {
   flex: 33.33%;
-  padding: 5px 5px 0 5px;
+  padding: 4px 5px 0 5px;
 }
 
 .logo .column .mit-logo {
@@ -678,14 +678,14 @@ ul {
 .logo .column .micromasters-logo {
   height: 23px;
   width: 263px;
-  margin-top: 8px;
+  margin-top: 7px;
 }
 
 .logo .divider-large {
   flex: 33.33%;
   width: 1px;
   height: 30px;
-  margin: 8px 10px 0 10px;
+  margin: 8px 12px 0 10px;
   border-left: 1px solid rgba(255, 255, 255, 0.5);
 }
 

--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -1,5 +1,5 @@
 /***** Header *****/
-$header-height: 50px;
+$header-height: 57px;
 
 .header {
   @include max-width-container;
@@ -8,8 +8,8 @@ $header-height: 50px;
   display: flex;
   height: $header-height;
   justify-content: space-between;
-  background-color: $mm-brand-bg-dark;
-  padding: 5px 15% 5px 15%;
+  background-color: $mm-brand-bg;
+  padding: 5px 2% 5px 2%;
 }
 
 .logo {
@@ -21,19 +21,20 @@ $header-height: 50px;
     padding: 5px 5px 0 5px;
 
     .mit-logo {
-      height: 20px;
-      width: 40px;
+      height: 36px;
+      width: 51px;
     }
     .micromasters-logo {
-      height: 20px;
-      width: 185px;
+      height: 23px;
+      width: 263px;
+      margin-top: 8px;
     }
   }
   .divider-large {
     flex: 33.33%;
     width: 1px;
-    height: 20px;
-    margin: 5px 5px 0 0;
+    height: 30px;
+    margin: 8px 10px 0 10px;
     border-left: 1px solid rgba(255, 255, 255, 0.5);
   }
 }

--- a/styles/_header.scss
+++ b/styles/_header.scss
@@ -18,7 +18,7 @@ $header-height: 57px;
   }
   .column {
     flex: 33.33%;
-    padding: 5px 5px 0 5px;
+    padding: 4px 5px 0 5px;
 
     .mit-logo {
       height: 36px;
@@ -27,14 +27,14 @@ $header-height: 57px;
     .micromasters-logo {
       height: 23px;
       width: 263px;
-      margin-top: 8px;
+      margin-top: 7px;
     }
   }
   .divider-large {
     flex: 33.33%;
     width: 1px;
     height: 30px;
-    margin: 8px 10px 0 10px;
+    margin: 8px 12px 0 10px;
     border-left: 1px solid rgba(255, 255, 255, 0.5);
   }
 }


### PR DESCRIPTION
## Description
Updates header design for the theme
Related to #12 

## Screenshots
**Desktop**
<img width="1440" alt="Screenshot 2021-04-12 at 6 05 49 PM" src="https://user-images.githubusercontent.com/34372316/114399046-ee0cbf80-9bb9-11eb-968f-4aeaf8bbbb19.png">

**Mobile**
<img width="448" alt="Screenshot 2021-04-12 at 6 08 46 PM" src="https://user-images.githubusercontent.com/34372316/114399284-2e6c3d80-9bba-11eb-82ba-319d9029e0b2.png">


## Testing instructions
- You can visit the live deployed theme [here](https://testmm.zendesk.com/hc/en-us).
- Making sure that the expected changes are reflected in the theme.